### PR TITLE
Fix AjaxAuthenticationSuccessHandler to better handle url generation (generates app_dev.php when necessary)

### DIFF
--- a/Security/Http/Authentication/AjaxAuthenticationSuccessHandler.php
+++ b/Security/Http/Authentication/AjaxAuthenticationSuccessHandler.php
@@ -17,14 +17,16 @@ class AjaxAuthenticationSuccessHandler extends DefaultAuthenticationSuccessHandl
      */
     public function onAuthenticationSuccess(Request $request, TokenInterface $token)
     {
+        $response = parent::onAuthenticationSuccess($request, $token);
+        
         if ($request->isXmlHttpRequest()) {
             return new JsonResponse(array(
                 'has_error'	  => false,
                 'username'	  => $token->getUser()->getUsername(),
-                'target_path' => $this->determineTargetUrl($request)
+                'target_path' => $response->getTargetUrl(),
             ));
         }
 
-        return parent::onAuthenticationSuccess($request, $token);
+        return $response;
     }
 }

--- a/Security/Http/Authentication/AjaxAuthenticationSuccessHandler.php
+++ b/Security/Http/Authentication/AjaxAuthenticationSuccessHandler.php
@@ -21,9 +21,9 @@ class AjaxAuthenticationSuccessHandler extends DefaultAuthenticationSuccessHandl
         
         if ($request->isXmlHttpRequest()) {
             return new JsonResponse(array(
-                'has_error'	  => false,
-                'username'	  => $token->getUser()->getUsername(),
-                'target_path' => $response->getTargetUrl(),
+                'has_error'     => false,
+                'username'      => $token->getUser()->getUsername(),
+                'target_path'   => $response->getTargetUrl(),
             ));
         }
 


### PR DESCRIPTION
The DefaultAuthenticationSuccessHandler class handles URL generation like this :

``` php
$this->httpUtils->createRedirectResponse($request, $this->determineTargetUrl($request));
```

Instead of just :

``` php
$this->determineTargetUrl($request);
```

The createRedirectResponse method itself relies on the <code>HttpUtils::generateUri()</code> method that adds the <code>/app_dev.php/</code> when necessary.

There are 2 approaches to this problem.
1. Copy and paste the URL generation logic inside your child SuccessHandler
2. Use the RedirectResponse::getTargetUrl() method to get the generated URL

The second approach seems cleaner to me, let me know your opinion on this matter :)
