### PR TITLE
Adding symfony 2.0-2.1 requirement in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     ],
     
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=5.3.2",
+        "symfony/symfony": ">=2.0,<2.2"
     },
     "autoload": {
         "psr-0": { "Divi\\AjaxLoginBundle": "" }


### PR DESCRIPTION
Hello,

Here the same pull Request for the 2.0-2.1 symfony requirements.

If someone tries to require this branch with a wrong symfony version, composer will display this message :

<pre>
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for divi/ajax-login-bundle dev-composer-2.0 -> satisfiable by divi/ajax-login-bundle[dev-composer-2.0].
    - divi/ajax-login-bundle dev-composer-2.0 requires symfony/symfony >=2.0,<2.2 -> no matching package found.
</pre>


Regards,
Jérôme
